### PR TITLE
Suggestions from Pam

### DIFF
--- a/Releases/copyleft-next-0.1.0
+++ b/Releases/copyleft-next-0.1.0
@@ -3,7 +3,7 @@
 
 1. License Grants.
 
-   Subject to the terms and the conditions in paragraphs 4-5 and 7-9 of this License, We grant You:
+   Subject to the terms and the conditions in paragraphs 4, 5 and 7 through 9 of this License, We grant You:
 
    a) A non-exclusive, worldwide, perpetual, royalty-free, irrevocable 
       copyright license, to reproduce, distribute, prepare derivative works, publicly perform and 

--- a/Releases/copyleft-next-0.1.0
+++ b/Releases/copyleft-next-0.1.0
@@ -11,10 +11,10 @@
 
    b) A non-exclusive, worldwide, perpetual, royalty-free, irrevocable 
       patent license under Licensed Patents to make, have made, use, sell, 
-      offer for sale, import and otherwise transfer Covered Works. 
+      offer for sale, and import Covered Works. 
 
    This License does not exclude or limit any rights You would have under 
-   applicable copyright law except as expressly described in this License.
+   applicable copyright law.
 
 2. No Trademark License.
 
@@ -181,7 +181,7 @@
     "Distributor" means Us and anyone else who Distributes a Covered Work.
 
     "Licensed Patents" means all patent claims licensable by Us, now or in 
-    the future, that are necessarily infringed by making, using, or selling 
+    the future, that are necessarily infringed by making, having made, using, selling, offering for sale, or importing 
     the Received Work, and excludes claims that would be infringed only as 
     a consequence of further modification of the Received Work.
 

--- a/Releases/copyleft-next-0.1.0
+++ b/Releases/copyleft-next-0.1.0
@@ -173,12 +173,12 @@
 
     "Derived Work" means a work of authorship that copies from, modifies,
     adapts, is based on, contains, transforms or translates all or part of
-    the Received Work such that copyright permission is required. Derived
+    the Received Work. Derived
     Works do not include Mere Aggregation or the mere making of a verbatim
     copy of the Received Work.
 
-    "Distribute" means to distribute, transfer or make available a copy to 
-    someone else, such that copyright permission is required.
+    "Distribute" means to distribute, transfer or make available a copy of the Covered Work to 
+    someone else.
 
     "Distributor" means Us and anyone else who Distributes a Covered Work.
 

--- a/Releases/copyleft-next-0.1.0
+++ b/Releases/copyleft-next-0.1.0
@@ -38,7 +38,7 @@
    applicable conditions of sections 5 and 7 through 9; and (iii) preserve all 
    Legal Notices contained in the Received Work (to the extent they remain 
    pertinent). "Legal Notices" means copyright notices, license notices, 
-   license texts, and author attributions, but does not include logos or 
+   license texts, and author attributions, but does not include logos and their legends or 
    other graphical images.
 
 5. Distributing Derived Works.

--- a/Releases/copyleft-next-0.1.0
+++ b/Releases/copyleft-next-0.1.0
@@ -3,7 +3,7 @@
 
 1. License Grants.
 
-   Subject to the terms and the conditions in paragraphs 4-5 and 6-9 of this License, We grant You:
+   Subject to the terms and the conditions in paragraphs 4-5 and 7-9 of this License, We grant You:
 
    a) A non-exclusive, worldwide, perpetual, royalty-free, irrevocable 
       copyright license, to reproduce, Distribute, prepare derivative works, publicly perform and 

--- a/Releases/copyleft-next-0.1.0
+++ b/Releases/copyleft-next-0.1.0
@@ -28,7 +28,7 @@
    Work had You prepared it, under terms other than (i) a version of 
    copyleft-next released by the Copyleft-Next Project, (ii) a license 
    authorized under section 10, or (iii) a license approved by the Open 
-   Source Initiative as of 1 January 2013, sections 4 through 9 of this 
+   Source Initiative as of 1 January 2013, sections 4, 5 and 7 through 9 of this 
    License no longer apply to You.
 
 4. Distribution: General Conditions.

--- a/Releases/copyleft-next-0.1.0
+++ b/Releases/copyleft-next-0.1.0
@@ -6,7 +6,7 @@
    Subject to the terms and the conditions in paragraphs 4-5 and 7-9 of this License, We grant You:
 
    a) A non-exclusive, worldwide, perpetual, royalty-free, irrevocable 
-      copyright license, to reproduce, Distribute, prepare derivative works, publicly perform and 
+      copyright license, to reproduce, distribute, prepare derivative works, publicly perform and 
       publicly display Covered Works, in any medium.
 
    b) A non-exclusive, worldwide, perpetual, royalty-free, irrevocable 

--- a/Releases/copyleft-next-0.1.0
+++ b/Releases/copyleft-next-0.1.0
@@ -3,19 +3,18 @@
 
 1. License Grants.
 
-   Subject to the terms and conditions of this License, We grant You:
+   Subject to the terms and the conditions in paragraphs 4-5 and 6-9 of this License, We grant You:
 
    a) A non-exclusive, worldwide, perpetual, royalty-free, irrevocable 
-      copyright license, to make, copy, Distribute, publicly perform and 
+      copyright license, to reproduce, Distribute, prepare derivative works, publicly perform and 
       publicly display Covered Works, in any medium.
 
    b) A non-exclusive, worldwide, perpetual, royalty-free, irrevocable 
       patent license under Licensed Patents to make, have made, use, sell, 
       offer for sale, import and otherwise transfer Covered Works. 
 
-   This License does not exclude or limit any rights You have under 
-   applicable copyright doctrines of fair use, fair dealing or other
-   equivalents.
+   This License does not exclude or limit any rights You would have under 
+   applicable copyright law except as expressly described in this License.
 
 2. No Trademark License.
 
@@ -36,7 +35,7 @@
 
    You may Distribute Covered Works, provided that You (i) inform 
    recipients how they can obtain a copy of this License; (ii) satisfy the 
-   applicable conditions of sections 5 through 9; and (iii) preserve all 
+   applicable conditions of sections 5 and 7 through 9; and (iii) preserve all 
    Legal Notices contained in the Received Work (to the extent they remain 
    pertinent). "Legal Notices" means copyright notices, license notices, 
    license texts, and author attributions, but does not include logos or 
@@ -88,7 +87,7 @@
 
 10. Outbound (A)GPL Compatibility.
 
-    You may Distribute a Covered Work under one or more of the following
+    You may Distribute a Derived Work under one or more of the following
     licenses published by the Free Software Foundation: (i) GNU General 
     Public License, version 2; (ii) GNU Affero General Public License, 
     version 3; (iii) later versions of the foregoing licenses.
@@ -117,8 +116,7 @@
 
     The Copyleft-Next Project may release new versions of copyleft-next, 
     designated by a distinguishing version number ("Later Versions"). 
-    Unless We explicitly remove the option of Distributing Covered Works 
-    under Later Versions, You may Distribute Covered Works under any Later 
+    You may Distribute Covered Works under any Later 
     Version.
 
 **************************************************************************
@@ -167,7 +165,7 @@
     Works (other than those provided in compliance with (ii)) that were 
     specifically used in building and installing the Covered Work (for 
     example, a specified proprietary compiler including its version 
-    number). Corresponding Source must be machine-readable.
+    number).
 
     "Covered Work" means the Received Work or a Derived Work.
 
@@ -177,7 +175,7 @@
     Works do not include Mere Aggregation or the mere making of a verbatim
     copy of the Received Work.
 
-    "Distribute" means to distribute, transfer or make available a copy of a Covered Work to 
+    "Distribute" means to distribute, transfer or make a Covered Work available to 
     someone else.
 
     "Distributor" means Us and anyone else who Distributes a Covered Work.
@@ -211,6 +209,6 @@
     in the Received Work under this License. For legal entities, “You” 
     includes any entity that controls, is controlled by, or is under common 
     control with You. “Control” means (a) the power, direct or indirect, to 
-    cause the direction or management of such entity, whether by contract 
+    direct the actions of such entity, whether by contract 
     or otherwise, or (b) ownership of more than fifty percent of the 
     outstanding shares or beneficial ownership of such entity.

--- a/Releases/copyleft-next-0.1.0
+++ b/Releases/copyleft-next-0.1.0
@@ -38,8 +38,8 @@
    applicable conditions of sections 5 and 7 through 9; and (iii) preserve all 
    Legal Notices contained in the Received Work (to the extent they remain 
    pertinent). "Legal Notices" means copyright notices, license notices, 
-   license texts, and author attributions, but does not include logos and their legends or 
-   other graphical images.
+   license texts, and author attributions, but does not include logos,
+   other graphical images, and trademark legends.
 
 5. Distributing Derived Works.
 

--- a/Releases/copyleft-next-0.1.0
+++ b/Releases/copyleft-next-0.1.0
@@ -177,7 +177,7 @@
     Works do not include Mere Aggregation or the mere making of a verbatim
     copy of the Received Work.
 
-    "Distribute" means to distribute, transfer or make available a copy of the Covered Work to 
+    "Distribute" means to distribute, transfer or make available a copy of a Covered Work to 
     someone else.
 
     "Distributor" means Us and anyone else who Distributes a Covered Work.


### PR DESCRIPTION
I have no idea whether I've done this right. I modified only the release version of the license, nothing else. Sorry it's here; I realize that you switched to gitorious but I'm completely baffled by how I get my change from my computer to gitorious to then make a merge request, so I gave up for now.  But if you can't see my changes here then I guess I equally failed understanding github.

Explanation for changes:

1 preamble: Given that US courts have to construe what is a “condition” and what is a “covenant,” although it's fairly obvious I would expressly identify what you consider to be the conditions. Paragraph 6 isn't a condition, so I excluded that from the enumeration, although ideally I would re-order the paragraphs and put 6 after current paragraph 10 so the enumeration would be easier. Alternatively, rather than listing the conditions by paragraph number, you could instead put the word “condition” in the title for all the relevant paragraphs. (+9 words)  

1(a): In the grant, my practice is to use the statutory language (admittedly U.S.) of the exclusive rights of the author so it's unassailably clear which rights you are licensing. If you don't like that, I would be ok with “copy” instead of "reproduce" (although there are statements in case law that “copy” is shorthand for “infringe any of the exclusive rights of the author,” so using the word “copy” leaves room for a little bit of mischief) but I have no idea what “make” might mean in a copyright context. (I think compiling the source code would be preparing derivative work, so that wouldn't be “making” a work.) You also should specifically grant the right to prepare derivative works – it's clearly intended and implied, but a little odd not to expressly state it when it's probably the most important right you're granted. I debated whether to say “prepare Derived Works” or “prepare derivative works” and decided the latter was right because then there couldn't be any ambiguity about whether there was some type of derivative work that the license didn't allow you to create, i.e., one that would be a derivative work but that wouldn't be a Derived Work. For the same reason I lower-cased “Distribute,” to make it clear that you were granting a license for all distribution rights, not just ones you define. 

You might want to consider looking at foreign law to see whether there are any other concepts you should include in the grant. (+2 words, net +11)

1(b): I struck “or otherwise transfer” because “transferring” is not a patent infringement so it doesn't need to be licensed. (-2 words, net +9)

1 after (b): There are many defenses to infringement, not just fair use. I don't think you mean to limit these other defenses, either. (-7 words, net +2)

3: Same reference that 6 is not a condition, so I carved it out. (+2 words, net +4)

4: Same reference that 6 is not a condition, so I carved it out.  I also said expressly that trademark legends don't have to be included, although they are legal notices so creates a bit of ambiguity to say they're not. But I think it's ok. (+4 words, net +8)

10: Based on paragraph 6, the Received Work is licensed to the distributee under copyleft-next, so it's only the Derived Work that would be under an alternative license. And maybe not even really that; it might be just the delta between the Received Work and the Derived Work that would be under the new license. But I concede that my change, although I believe more accurate, might create confusion. (no change)

12: Struck the “unless” clause. It talks about what might happen in the future—is it necessary to put anyone on notice that you might remove the provision in the future? Can't you just do it? (-13 words, net -5)

16, “Corresponding Source”: I'm not sure what “Corresponding Source must be machine readable” is supposed to accomplish so I struck it. If I give it to you on paper but it can be scanned and OCR'ed, I think of that as “machine readable” but probably not suitable for your purpose. Maybe if you defined it in terms of what the receiver must be able do with it? (-6 words, net -11)

16, “Derived Work”: This is the one that caught my eye during your talk. It's not a circularity problem but a (less harmful) redundancy. I struck “such that copyright permission is required” because it doesn't add anything. A Derived Work by definition requires permission to create; if it didn't it's not an infringement and the license doesn't need to be invoked. I agree, though, that it seems clearer with the extra wording so it might be worth the verbosity sacrifice. (-6 words, net -17)

16, “Distribute”: I wanted to get rid of “such that copyright permission is required” here too, plus I was troubled by the absence of an object in the sentence, so added that. Also, I struck “a copy.” I think that the distribution would be of a copy is obvious, but I also wonder if, by saying “copy” you are leaving room for an argument that a web-hosted program isn't “a copy.” (-5 words, net -22)

16, “Licensed Patents”: added the rest of the acts of infringement so the language parallels the grant, i.e., you were missing having made, offering for sale, and importing. (+6 words, net -16)

16, “You”/”Your”: I have no idea what “cause the direction or management” means. I substituted “direct the actions of” as an alternative, but I still think there's probably a better way to say it. (-2 words, net -18)

I assume you considered, but decided not to include, a license of moral rights.

I assume you considered, but decided not to include, a choice of law provision.
