### PR TITLE
Changes summarized in comment

### DIFF
--- a/Drafts/copyleft-next
+++ b/Drafts/copyleft-next
@@ -4,37 +4,33 @@ THIS IS A DRAFT. DO NOT USE AS A LICENSE.
 
 0. Basic Definitions
 
+   "Covered Code" means a set of files consisting of My Code and/or
+   Modified Code. Covered Code includes all Neighboring
+   Code that is Distributed with Covered Code, but Neighboring Code in
+   isolation is not Covered Code.
+
    "I"/"Me" refers to the individual or legal entity that places My
    Code under this License.
-
-   "You"/"Your" refers to the individual or legal entity exercising
-   rights in My Code under this License. A legal entity includes each
-   entity that controls, is controlled by, or is under common control
-   with such legal entity. "Control" means (a) the power to direct the
-   actions of such legal entity, whether by contract or otherwise, or
-   (b) ownership of more than fifty percent of the outstanding shares
-   or beneficial ownership of such legal entity.
-
-   "Source Code Form" of Covered Code means the preferred form for
-   making modifications to the Covered Code.
-
-   "My Code" means the set of files in Source Code Form comprising the
-   work of authorship that I license to You under this License,
-   including any portion thereof.
 
    "Modified Code" means one or more files resulting from an addition
    to, deletion from, or other modification of the contents of one or
    more files in My Code, or (b) one or more new files containing
    portions of My Code.
 
+   "My Code" means the set of files in Source Code Form comprising the
+   work of authorship that I license to You under this License,
+   including any portion thereof.
+
    "Neighboring Code" means one or more files that specifically use
    functions or data declared or defined in My Code, but which are not
    Modified Code.
 
-   "Covered Code" means a set of files consisting of My Code and/or
-   Modified Code. Covered Code additionally includes all Neighboring
-   Code that is Distributed with Covered Code, but Neighboring Code in
-   isolation is not Covered Code.
+   "Source Code Form" of Covered Code means the preferred form for
+   making modifications to the Covered Code.
+
+   "You"/"Your" refers to the individual or legal entity exercising
+   rights in My Code under this License.
+   
 
 1. Copyright and Patent License Grants
 
@@ -56,19 +52,19 @@ THIS IS A DRAFT. DO NOT USE AS A LICENSE.
 3. Lawful Uses Unaffected
 
    This License does not exclude or limit any rights you have under
-   copyright or other applicable law.
+   copyright or other applicable law, including, but not limited to, fair use and 
+   fair dealing rights.
 
 4. General Conditions for Distributing Covered Code
 
    If You Distribute Covered Code, You must (i) inform recipients how they
    can obtain a copy of this License; (ii) satisfy the applicable
-   conditions of sections 4 through 7; and (iii) preserve all Legal Notices
-   contained in My Code (to the extent they remain pertinent). "Legal
-   Notices" means copyright notices, license notices, license texts,
-   warranty disclaimers, and author attributions, but does not include
-   logos, other graphical images, trademarks or trademark legends.
+   conditions of Sections 4 through 7; and (iii) preserve all Legal Notices
+   contained in My Code. "Legal Notices" means copyright notices, license notices, 
+   license texts, warranty disclaimers, and author attributions, but does not 
+   include logos, other graphical images, trademarks or trademark legends.
 
-3. Distributing Covered Code: Copyleft Conditions and Pass-Through
+5. Distributing Covered Code: Copyleft Conditions and Pass-Through
 
    When You Distribute Covered Code, the recipient automatically receives
    a license to My Code from Me, subject to the terms of this License.
@@ -82,15 +78,16 @@ THIS IS A DRAFT. DO NOT USE AS A LICENSE.
    compliance with conditions or obligations extrinsic to this License
    (such as a court order or an agreement with a third party).
 
-4. Copyleft Conditions: Exceptions and Limitations
+6. Copyleft Conditions: Exceptions and Limitations
 
    Unless I explicitly remove the option, You may additionally or
    alternatively Distribute Covered Code under a Later Version. In such a
-   case, [FIXME].
+   case, You may only Distribute Covered Code under This Version.
 
-   You may additionally Distribute Covered Code under the GPL, so that a
-   recipient may further Distribute such Covered Code under either this
-   License (and/or a Later Version) and/or the GPL.
+   Notwithstanding any other Section of this License, You may additionally 
+   Distribute Covered Code under the GPL, so that a recipient may further 
+   Distribute such Covered Code under either this License (and/or a Later 
+   Version) and/or the GPL.
 
    You may Distribute a Modification under this License even if it
    incorporates third-party material governed by a license that is both
@@ -98,13 +95,13 @@ THIS IS A DRAFT. DO NOT USE AS A LICENSE.
    provided that such other license does not itself prevent You from
    Distributing the Modification under this License. Compatibility of
    other third-party licenses must be measured against the requirement of
-   the final paragraph of section 3 of this License.
+   the final paragraph of Section 5 of this License.
 
    You may license an Aggregate under terms of Your choice, provided
    that such terms are consistent with the conditions of this License as
    to Covered Code contained in the Aggregate.
 
-5. Conditions for Distributing Object Code Forms
+7. Conditions for Distributing Object Code Forms
 
    You may Distribute an Object Code Form of Covered Code, provided that
    you accompany the Object Code Form with a URL through which the
@@ -114,16 +111,17 @@ THIS IS A DRAFT. DO NOT USE AS A LICENSE.
    If you Distribute the Object Code Form in a physical product or tangible
    storage medium ("Product"), the Corresponding Source must be available
    through such URL for two years from the date of Your most recent
-   Distribution of the Object Code Form in the Product. However, if the
-   Product itself contains or is accompanied by the Corresponding Source
+   Distribution of the Object Code Form in the Product. 
+   
+   If the Product itself contains or is accompanied by the Corresponding Source
    (made available in a customarily accessible manner), You need not also
-   comply with the first paragraph of this section.
+   comply with the first two paragraphs of this section.
 
    Each recipient of Covered Code from You is an intended third-party
    beneficiary of this License solely as to this section 5, with the right
    to enforce its terms.
 
-6. Symmetrical Licensing Condition for Upstream Contributions
+8. Symmetrical Licensing Condition for Upstream Contributions
 
    If You Distribute a work to Me specifically for inclusion in or
    modification of Covered Code (a "Patch"), and no explicit licensing
@@ -131,23 +129,23 @@ THIS IS A DRAFT. DO NOT USE AS A LICENSE.
    the extent of Your copyright in the Patch. This condition does not
    negate the other conditions of this License, if applicable to the Patch.
 
-7. Nullification of Copyleft/Proprietary Dual Licensing
+9. Nullification of Copyleft/Proprietary Dual Licensing
 
    If I offer to license, for a fee, Covered Code under terms other than
    a license that is OSI-Approved or FSF-Free as of the release date of this
    License or a numbered version of copyleft-next released by the
    Copyleft-Next Project, then the license I grant You under section 1 is no
-   longer subject to the conditions in sections 2 through 5.
+   longer subject to the conditions in Sections 5 through 8.
 
-8. Copyleft Sunset
+10. Copyleft Sunset
 
-   The conditions in sections 2 through 5 no longer apply once fifteen
+   The conditions in Sections 5 through  8no longer apply once fifteen
    years have elapsed from the date of My first Distribution of My Code
    under this License.
 
 10. Termination
 
-    Your license grants under section 1 are automatically terminated if You
+    Your license grants under Section 1 are automatically terminated if You
 
     a) fail to comply with the conditions of this License, unless You cure
        such noncompliance within thirty days after becoming aware of it, or
@@ -177,17 +175,18 @@ THIS IS A DRAFT. DO NOT USE AS A LICENSE.
 **                                                                       **
 **     To the extent permitted by applicable law, in no event will any   **
 **     Distributor of My Code be liable to You for any damages           **
-**     whatsoever, whether direct, indirect, special, incidental, or     **
-**     consequential damages, whether arising under contract, tort       **
-**     (including negligence), or otherwise, even where the Distributor  **
-**     knew or should have known about the possibility of such damages.  **
+**     whatsoever, whether direct, indirect, special, incidental,        **
+**     statutory or consequential damages, whether arising under         **
+**     contract, tort (including negligence), or otherwise, even where   **
+**     the Distributor knew or should have known about the possibility   **
+**     of such damages.                                                  **
 
 13. Severability
 
     The invalidity or unenforceability of any provision of this License
     does not affect the validity or enforceability of the remainder of
     this License. Such provision is to be reformed to the minimum extent
-    necessary to make it valid and enforceable.
+    necessary to make it valid and enforceabl.e
 
 14. Definitions
 


### PR DESCRIPTION
Here are the changes I made:

I deleted the definition of "Legal Entity". This makes it easier and cheaper to bring corporate entities into compliance with copyleft-next; enforcement through litigation won't need to delve as deeply into proving how an the infringing corporate body is governed.

I alphabetized the first Definitions list.

I corrected the numbering of the Sections in the license.

I capitalized Section to improve readability.

Section 4: deleted parenthetical phrase "to the extent they remain pertinent". Allowing code recipients to delete Legal Notices as long as they meet a vaguely worded obligation could encourage circumvention of copyleft-next.

Section 6: Made an effort to address the FIXME. 

Section 6: Added a notwithstanding statement to paragraph 2. That would make the license a lot simpler for developers who want to know quickly whether or not the license is GPL-compatible.

Section 7: attempted to clarify what I understood to be an exception to the URL requirement

Sections 9 and 10: changed Section numbers referenced to ones I believe were intended to be covered.

Section 12: added statutory damages to the list of liability limitations.

Thanks,
Adam Saunders
