### PR TITLE
Remove whitespace from blank line

### DIFF
--- a/Drafts/copyleft-next-0.3.1-SNAPSHOT
+++ b/Drafts/copyleft-next-0.3.1-SNAPSHOT
@@ -36,7 +36,7 @@ THIS IS A DRAFT. DO NOT USE AS A LICENSE.
 
    If the Derived Work includes material licensed under the GPL, You may
    instead license the Derived Work under the GPL.
-   
+
 4. Condition Against Further Restrictions; Inbound License Compatibility
 
    When Distributing a Covered Work, You may not impose further


### PR DESCRIPTION
Noticed a few spaces on a blank line while reading. Hopefully I managed to zap them in the right place. CONTRIBUTING helpfully pointed me to `./Drafts`, but `./Drafts/copyleft-next` seems out-of-date.

In any event, feel free to toss this PR and nail the spaces wherever they actually live.

I do plan to actually read the license. If anything comes of that, I'll send your way.

Best,

K