### PR TITLE
Substitute spaces for tabs in Appendix A

### DIFF
--- a/Drafts/copyleft-next
+++ b/Drafts/copyleft-next
@@ -254,8 +254,8 @@ MPL 2.0               http://www.mozilla.org/MPL/2.0/
 EPL 1.0               http://www.eclipse.org/legal/epl-v10.html
 
 GPL-Family Licenses:
-GPLv2		      http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+GPLv2                 http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
 LGPLv2.1              http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html
 GPLv3                 http://www.gnu.org/licenses/gpl-3.0-standalone.html
 LGPLv3                https://www.gnu.org/licenses/lgpl.html
-AGPLv3		      https://www.gnu.org/licenses/agpl.html
+AGPLv3                https://www.gnu.org/licenses/agpl.html


### PR DESCRIPTION
Appendix A contained a few inconsistent uses of tabs over the usual spaces for indentation. I propose standardizing around spaces.