### PR TITLE
Enhancement Defined

### DIFF
--- a/Drafts/copyleft-next
+++ b/Drafts/copyleft-next
@@ -15,6 +15,8 @@ THIS IS A DRAFT. DO NOT USE AS A LICENSE.
    with My Work through a published interface or merely makes reference to
    My Work.
 
+   "Enhancement" means a Covered Work other than My Work.
+
    "Separate Work" means a work that is (i) separate from and independent
    of a particular Covered Work and is not by its nature an extension or
    enhancement of the Covered Work, and/or is (ii) a runtime library,


### PR DESCRIPTION
Enhancement is being used as a defined term in the license and needs some form of definition. It looks like the text of the definition for Enhancement was merged into the definition for Covered Work. I propose a minimal definition for Enhancement as any 'Covered Work other than My Work' to differentiate between what another license might term "verbatim" copies of My Work and a "work based on" My Work.

One non-defined use of enhancement is retained on line 22:
> and is not by its nature an extension or enhancement of the Covered Work

Under the proposed definition, the use of "Enhancement" here would render "extension" superfluous. 